### PR TITLE
Fix reactions modal

### DIFF
--- a/project_stories/static/modal.js
+++ b/project_stories/static/modal.js
@@ -65,9 +65,16 @@ const init_modals = function() {
         const response = await fetch(trigger.dataset.href, {method: 'GET'});
         if (response.status === 200) {
             const data = await response.text();
+
+            // Extract the <main> element from the response text
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(data, "text/html");
+            const mainElement = doc.querySelector("main");
+            const mainHtml = mainElement.outerHTML;
+
             const body = target && target.querySelector(".modal__wrapper");
             if (body) {
-                body.innerHTML = data;
+                body.innerHTML = mainHtml;
                 addModalListeners();
             }
         }

--- a/project_stories/static/modal.js
+++ b/project_stories/static/modal.js
@@ -65,16 +65,9 @@ const init_modals = function() {
         const response = await fetch(trigger.dataset.href, {method: 'GET'});
         if (response.status === 200) {
             const data = await response.text();
-
-            // Extract the <main> element from the response text
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(data, "text/html");
-            const mainElement = doc.querySelector("main");
-            const mainHtml = mainElement.outerHTML;
-
             const body = target && target.querySelector(".modal__wrapper");
             if (body) {
-                body.innerHTML = mainHtml;
+                body.innerHTML = data;
                 addModalListeners();
             }
         }

--- a/project_stories/templates/comments/object_reactions_form.html
+++ b/project_stories/templates/comments/object_reactions_form.html
@@ -5,7 +5,7 @@
   <form method="POST" autocomplete="off" action="{% object_reactions_form_target object %}" id="reactions">
     {% csrf_token %}
     <input type="hidden" name="{{ comments_page_qs_param }}" value="{{ cpage }}" />
-    <input type="hidden" name="{{ comments_fold_qs_param }}" value="{{ cfold }}" />
+    <input type="hidden" name="{{ comments_folded_qs_param }}" value="{{ cfold }}" />
     <input type="hidden" name="next" value="{{ object.get_absolute_url }}#reactions" />
     <div class="flex flex-align-center">
       {% for reaction in object_reactions %}

--- a/project_stories/templates/comments/users_reacted_to_object.html
+++ b/project_stories/templates/comments/users_reacted_to_object.html
@@ -1,0 +1,1 @@
+list_reacted_to_object.html


### PR DESCRIPTION
As per https://github.com/comments-ink/django-comments-ink/discussions/59 , there seems to be a miss-match between the name of the template used in [`views.reacting.ReactedToObjectUserListView`](https://github.com/comments-ink/django-comments-ink/blob/85b9eb3cdd2e7bd3215208902cd01f72dbce793a/django_comments_ink/views/reacting.py#L303) and the code that would work with `modal.js`.

Here I've only created a link to `list_reacted_to_object.html` (which seems to be what modal.js expects), with the name used in the view, but it's not the ideal solution.

I'm not sure how to proceed:
1. change the name of the template here?
2. change the name of the template in the view?

I think `list_reacted` is not used as template name in django-comments-ink, so I'd be inclined toward solution 1 :slightly_smiling_face: 

This PR depends on [this PR](https://github.com/comments-ink/django-comments-ink/pull/60) on the main project side.