### PR TITLE
Use 2-column grid within modal window

### DIFF
--- a/project_stories/static/modal.css
+++ b/project_stories/static/modal.css
@@ -72,18 +72,18 @@
     margin: 20px;
 }
 
+@media screen and (max-width: 839px) {
+    .modal__wrapper {
+        max-width: 80vw;
+    }
+}
+
 @media screen and (min-width: 840px) {
     .modal__wrapper {
         max-width: 732px;
     }
     .modal__wrapper .container {
         width: calc(732px - 2.4rem);
-    }
-}
-
-@media screen and (max-width: 839px) {
-    .modal__wrapper {
-        max-width: 80vw;
     }
 }
 
@@ -95,6 +95,10 @@
     flex-grow: 1;
     /* Optional */
     padding: 1.5rem;
+}
+
+.modal__content .users-grid {
+    grid-template-columns: 1fr 1fr;
 }
 
 .modal.is-active {


### PR DESCRIPTION
This PR updates the `main.css` used in this project.
When clicking on the `77` number (mentioned [here](https://github.com/comments-ink/django-comments-ink/discussions/59#discussioncomment-9046022)) the modal window displays a grid of 3 columns with the users that reacted to the story. The changes to `main.css` introduced here modify the grid so that instead of displaying 3 columns it displays 2.